### PR TITLE
added support for webcomponents as jsx value-based elements

### DIFF
--- a/packages/tsx-dom/src/createElement.ts
+++ b/packages/tsx-dom/src/createElement.ts
@@ -1,15 +1,17 @@
 import { setAttributes } from "./setAttributes";
-import type { ComponentAttributes, ComponentChild, Component } from "./types";
-import { applyChildren, createDomElement } from "./utils";
+import type { Component, ComponentAttributes, ComponentChild } from "./types";
+import { applyChildren, createDomElement, isClassConstuctor } from "./utils";
 
 export function createElement(
-    tag: string | Component,
+    Tag: string | Component,
     attrs: null | ComponentAttributes,
     ...children: ComponentChild[]
 ): JSX.Element {
-    if (typeof tag === "function") return tag({ ...attrs, children });
+    if (typeof Tag === "function") {
+        return isClassConstuctor(Tag) ? new Tag({ ...attrs, children }) : Tag({ ...attrs, children });
+    }
 
-    const element = createDomElement(tag, attrs);
+    const element = createDomElement(Tag, attrs);
 
     if (attrs) setAttributes(element, attrs as ComponentAttributes);
 

--- a/packages/tsx-dom/src/jsx-runtime.ts
+++ b/packages/tsx-dom/src/jsx-runtime.ts
@@ -1,12 +1,14 @@
 import { setAttributes } from "./setAttributes";
-import type { BaseProps, ComponentAttributes, Component } from "./types";
-import { applyChildren, createDomElement } from "./utils";
+import type { BaseProps, Component, ComponentAttributes } from "./types";
+import { applyChildren, createDomElement, isClassConstuctor } from "./utils";
 
-export function jsx(tag: string | Component, props: BaseProps): JSX.Element {
-    if (typeof tag === "function") return tag(props);
-
+export function jsx(Tag: string | Component, props: BaseProps): JSX.Element {
     const { children, ...attrs } = props;
-    const element = createDomElement(tag, attrs as ComponentAttributes);
+    if (typeof Tag === "function") {
+        return isClassConstuctor(Tag) ? new Tag({ ...attrs, children }) : Tag({ ...attrs, children });
+    }
+
+    const element = createDomElement(Tag, attrs as ComponentAttributes);
 
     if (attrs) setAttributes(element, attrs as ComponentAttributes);
 
@@ -14,4 +16,4 @@ export function jsx(tag: string | Component, props: BaseProps): JSX.Element {
     return element;
 }
 
-export { jsx as jsxs, jsx as jsxDEV };
+export { jsx as jsxDEV, jsx as jsxs };

--- a/packages/tsx-dom/src/types.ts
+++ b/packages/tsx-dom/src/types.ts
@@ -1,11 +1,13 @@
-import type { EventAttributes, StyleAttributes, SVGAttributes, HTMLAttributes } from "tsx-dom-types";
+import type { EventAttributes, HTMLAttributes, SVGAttributes, StyleAttributes } from "tsx-dom-types";
 
 export type ComponentChild = ComponentChild[] | JSX.Element | string | number | boolean | undefined | null;
 export type ComponentChildren = ComponentChild | ComponentChild[];
 export interface BaseProps {
     children?: ComponentChildren;
 }
-export type Component = (props: BaseProps) => JSX.Element;
+export type NativeWebComponent = new (props: BaseProps) => JSX.Element;
+export type JsxComponent = (props: BaseProps) => JSX.Element;
+export type Component = JsxComponent | NativeWebComponent;
 export type ComponentAttributes = {
     [s: string]: string | number | boolean | undefined | null | StyleAttributes | EventListenerOrEventListenerObject;
 };

--- a/packages/tsx-dom/src/utils.ts
+++ b/packages/tsx-dom/src/utils.ts
@@ -1,4 +1,4 @@
-import { ComponentAttributes, ComponentChild } from "./types";
+import { Component, ComponentAttributes, ComponentChild, NativeWebComponent } from "./types";
 
 function applyChild(element: JSX.Element, child: ComponentChild) {
     if (child instanceof Element) element.appendChild(child);
@@ -22,4 +22,9 @@ export function createDomElement(tag: string, attrs: ComponentAttributes | null)
     if (attrs?.xmlns) return document.createElementNS(attrs.xmlns as string, tag, options) as SVGElement;
 
     return document.createElement(tag, options);
+}
+
+export function isClassConstuctor(func: Component): func is NativeWebComponent {
+    const prototype = <PropertyDescriptor>Object.getOwnPropertyDescriptor(func, "prototype");
+    return !prototype.writable;
 }


### PR DESCRIPTION
# TL;DR
i added support for native webcomponents inside tsx-dom,
i made sure it passes all tests and linter control.

## Description

Hi, i've been using tsx-dom to create some framework-agnostic reusable UI elements.
i felt like a more complete support of webcomponents would be great for that task aswell so i added it in.

## Behaviour

### Before

```tsx
//webcomponent
class MyCustomElement extends HTMLElement {
    ...
}

customElements.define("my-custom-element", MyCustomElement);

//needed declaration of intrinsic element to avoid typescript errors
declare global {
  namespace JSX {
    interface IntrinsicElements {
      "my-custom-element": any;
    }
  }
}

//can use webcomponent only by it's tagname
//cant pass complex data via attributes
//cant easily go to the class definition
const element = <my-custom-element example="value"></my-custom-element>
```

### After

```tsx
//web component
class MyHeader extends HTMLElement {
  props: { title: string };
  ....
}

customElements.define("my-header", MyHeader);

//can use webcomponent by className
//can pass complex data to contructor through props (with working types and intellisense)
//can easily got to the class definition
const myHeader = <MyHeader title={"Hello"}></MyHeader>;
```

## Changes

the changes are really simple,
the most important part is in the createElement function (and jsx-runtime counterpart)
###  Before
only accepts function components
if className used as tagName this throws a runtime error
```tsx

if (typeof tag === "function") return tag({ ...attrs, children });
```
###  After
i check if the function is a class constructor (new function in utils) and if it is a use the "new" keyword to instantiate the class which create the corrisponding HTMLElement.
i use uppercase **"Tag"** beacuse your linter configuration wants it for constructor functions
```tsx
if (typeof Tag === "function") {
  return isClassConstuctor(Tag) ? new Tag({ ...attrs, children }) : Tag({ ...attrs, children });
}
```
