### PR TITLE
Add missing HTML attributes

### DIFF
--- a/packages/tsx-dom-types/src/HTMLAttributes.ts
+++ b/packages/tsx-dom-types/src/HTMLAttributes.ts
@@ -40,6 +40,7 @@ export interface HTMLAttributes {
     alt?: string;
     as?: string;
     async?: boolean;
+    autocapitalize?: string;
     autocomplete?: string;
     autofocus?: boolean;
     autoplay?: boolean;


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize and https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#autocorrect