### PR TITLE
Add missing HTML attribute autocorrect

### DIFF
--- a/packages/tsx-dom-types/src/HTMLAttributes.ts
+++ b/packages/tsx-dom-types/src/HTMLAttributes.ts
@@ -42,6 +42,7 @@ export interface HTMLAttributes {
     async?: boolean;
     autocapitalize?: string;
     autocomplete?: string;
+    autocorrect?: string;
     autofocus?: boolean;
     autoplay?: boolean;
     capture?: boolean | string;


### PR DESCRIPTION
After seeing the comment https://github.com/Lusito/tsx-dom/pull/24#issuecomment-2241567300, I restarted the push to standardize autocorrect in https://github.com/whatwg/html/pull/5841#issuecomment-2241610963.

That PR has now been merged, and the autocorrect attribute has been added to the standard in https://html.spec.whatwg.org/multipage/interaction.html#attr-autocorrect. According to https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/autocorrect#browser_compatibility, it is supported in Safari, and looking at https://bugzilla.mozilla.org/show_bug.cgi?id=1725806, it is implemented in Firefox 134.