### PR TITLE
Set `jsx-dev-runtime`

### DIFF
--- a/packages/tsx-dom/package.json
+++ b/packages/tsx-dom/package.json
@@ -20,7 +20,8 @@
   "author": "Santo Pfingsten",
   "exports": {
     ".": "./dist/index.js",
-    "./jsx-runtime": "./dist/jsx-runtime.js"
+    "./jsx-runtime": "./dist/jsx-runtime.js",
+    "./jsx-dev-runtime": "./dist/jsx-runtime.js"
   },
   "main": "dist/index.js",
   "typesVersions": {


### PR DESCRIPTION
To be honest, I don’t know why this change is needed, but I know it fixes my build. Feel free to close if there’s a better solution. I’m using swc, so maybe that changes things? Without this change, I get this error:

```
File: […]/src/index.tsx:1:1
  × Package subpath './jsx-dev-runtime' is not defined by "exports" in […]/node_modules/tsx-dom/package.json